### PR TITLE
feat/mypage에서 summary가 누락되는 오류 해결

### DIFF
--- a/recommendations/views.py
+++ b/recommendations/views.py
@@ -75,6 +75,15 @@ class SavedPlaceCreateView(generics.CreateAPIView):
     serializer_class = SavedPlaceCreateSerializer
     permission_classes = [permissions.AllowAny]
 
+    # summary_snapshot에 최신 ai요약 저장해 놓기 
+    def perform_create(self, serializer):
+        saved_place = serializer.save()
+        # 해당 Place의 최신 요약 가져오기
+        last_summary = saved_place.shop.ai_summary.order_by("-created_date").first()
+        if last_summary:
+            saved_place.summary_snapshot = last_summary.summary
+            saved_place.save()
+
 
 
 class SavedPlaceListView(generics.ListAPIView):


### PR DESCRIPTION
## 📌 이슈번호 및 PR 유형
closed #51 

---

## PR 유형 
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Refactor: 리팩토링(동작 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Chore: 빌드/배포/환경설정 등 잡무

---

## 📝 개요
- 마이페이지에서 가게 관련 필드 응답 시 summary가 누락되는 오류 해결 

---

## 🔍 변경 사항
AISummary 모델에, 과거 기록된 ai 요약을 저장하는 필드인 summary_snapshop을 만들었지만,
그 필드에 현재 내놓은 ai 요약을 저장하는 로직을 구현하지 않았었음.
-> recommendations/views.py에 추가함. 

---

## 📷 스크린샷(선택)
<img width="1799" height="511" alt="image" src="https://github.com/user-attachments/assets/b389e6b7-abd7-46c7-b753-5fbae9b298f4" />

비록 가끔 감정태그 배열이 오지 않는 오류가 발생하지만, 요약은 잘 전달된다!!

---

## Review Notes 
리뷰어에게 공유할 중요 사항이 있다면 알려주세요~!

---

## ✅ PR 전 체크리스트
작성하신 코드가 다음의 요구사항을 만족하는지 확인해주세요. 

- [x] 변경 사항에 대한 테스트 여부
- [ ] 불필요한 콘솔 로그 제거
